### PR TITLE
Add `allModules` to plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ addCommandAlias("ci-publish", "github; ci-release")
 
 lazy val documentation = project
   .enablePlugins(MdocPlugin)
+  .dependsOn(allModules: _*)
   .settings(mdocOut := file("."))
 
 lazy val `sbt-modules` = module

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@
 
 ```diff
 lazy val docs = project
+-  .dependsOn(allProjects: _*)
++  .dependsOn(allModules: _*)
   .in(file("docs"))
 
 + lazy val `my-library-core` = module
@@ -15,6 +17,11 @@ lazy val docs = project
 - lazy val plugin = project
 -   .in(file("modules/plugin"))
 -   .settings(name := "my-library-plugin")
+-
+- lazy val allProjects: Seq[ClasspathDep[ProjectReference]] = Seq(
+-   core,
+-   plugin
+- )
 ```
 
 ## Installation
@@ -31,7 +38,7 @@ Use `module` instead of `project` to create your SBT modules. Unlike `project`, 
 
 For example, the following SBT configuration:
 
-```scala
+```sbt
 lazy val `my-library-core` = module
 
 lazy val `my-library-plugin` = module 
@@ -48,6 +55,18 @@ Would expect the following directory structure:
 |       +-- src
 +-- build.sbt
 +-- project
+```
+
+### Retrieveing all modules created with `module`
+
+`sbt-modules` creates a special variable called `allModules` that aggregates all the modules created with `module`, so you can pass it along as a dependency to other projects in your build, like:
+
+```sbt
+lazy val documentation = project.dependsOn(allModules: _*)
+
+lazy val `my-library-core` = module
+
+lazy val `my-library-plugin` = module 
 ```
 
 [github-action]: https://github.com/alejandrohdezma/sbt-modules/actions

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/build.sbt
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/build.sbt
@@ -1,0 +1,13 @@
+lazy val a = module
+lazy val b = module
+
+lazy val c = project.dependsOn(allModules: _*)
+
+TaskKey[Unit]("check", "Checks c depends on a & b using `allModules`") := {
+  val expected = List(
+    ClasspathDependency(LocalProject("b"), None),
+    ClasspathDependency(LocalProject("a"), None)
+  )
+
+  assert(c.dependencies == expected, s"Found: ${c.dependencies}\nExpected: $expected")
+}

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/project/plugins.sbt
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-modules"   % sys.props("plugin.version"))

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/test
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/test
@@ -1,0 +1,2 @@
+# this test ensures `allModules` contains the list of modules
+> check


### PR DESCRIPTION
This PR introduces a special variable called `allModules` that aggregates all the modules created with `module`, so you can pass it along as a dependency to other projects in your build, like:

```sbt
lazy val documentation = project.dependsOn(allModules: _*)

lazy val `my-library-core` = module

lazy val `my-library-plugin` = module 
```