### PR TITLE
Enable automatic skip in publish for all projects (except those crated with `module`)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,10 @@
 [![][github-action-badge]][github-action] [![][maven-badge]][maven] [![][steward-badge]][steward] 
 
 ```diff
+- skip in publish := true
+- 
 lazy val docs = project
+-  .settings(skip in publish := true)
 -  .dependsOn(allProjects: _*)
 +  .dependsOn(allModules: _*)
   .in(file("docs"))
@@ -17,6 +20,8 @@ lazy val docs = project
 - lazy val plugin = project
 -   .in(file("modules/plugin"))
 -   .settings(name := "my-library-plugin")
+-   .dependsOn(core)
++   .dependsOn(`my-library-core`)
 -
 - lazy val allProjects: Seq[ClasspathDep[ProjectReference]] = Seq(
 -   core,
@@ -41,7 +46,7 @@ For example, the following SBT configuration:
 ```sbt
 lazy val `my-library-core` = module
 
-lazy val `my-library-plugin` = module 
+lazy val `my-library-plugin` = module.dependsOn(`my-library-core`) 
 ```
 
 Would expect the following directory structure:
@@ -66,7 +71,29 @@ lazy val documentation = project.dependsOn(allModules: _*)
 
 lazy val `my-library-core` = module
 
-lazy val `my-library-plugin` = module 
+lazy val `my-library-plugin` = module.dependsOn(`my-library-core`)
+```
+
+### Auto-`skip in publish`
+
+Forget about setting `skip in publish := true` again. Adding this plugin to your build will disable publishing for all the projects in the build (including the auto-generated root plugin), except for those created with `module`.
+
+However, if you also want to exclude any of those created with `module` you can always add `.settings(skip in publish := true)`.
+
+Example:
+
+```sbt
+// Will not be published
+lazy val documentation = project.dependsOn(allmodules: _*)
+
+// Will be published
+lazy val `my-library-plugin` = module.dependsOn(`my-library-core`)
+
+// Will be published
+lazy val `my-library-core` = module
+
+// Will not be published
+lazy val `my-library-util` = module.settings(skip in publish := true)
 ```
 
 [github-action]: https://github.com/alejandrohdezma/sbt-modules/actions

--- a/modules/sbt-modules/src/main/scala/com/alejandrohdezma/sbt/modules/ModulesPlugin.scala
+++ b/modules/sbt-modules/src/main/scala/com/alejandrohdezma/sbt/modules/ModulesPlugin.scala
@@ -19,6 +19,7 @@ package com.alejandrohdezma.sbt.modules
 import scala.collection.mutable
 import scala.reflect.macros._
 
+import sbt.Keys._
 import sbt._
 
 import scala.language.experimental.macros
@@ -65,6 +66,7 @@ object ModulesPlugin extends AutoPlugin {
 
       reify {
         val project = Project(name.splice, file("modules") / name.splice)
+          .settings(skip in publish := false)
 
         ModulesPlugin.autoImport.allModules += project
 
@@ -73,5 +75,7 @@ object ModulesPlugin extends AutoPlugin {
     }
 
   }
+
+  override def buildSettings: Seq[Def.Setting[_]] = Seq(publish / skip := true)
 
 }

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/build.sbt
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/build.sbt
@@ -1,13 +1,13 @@
 lazy val a = module
 lazy val b = module
+lazy val c = module.settings(skip in publish := true)
 
-lazy val c = project.dependsOn(allModules: _*)
+lazy val d = project.dependsOn(allModules: _*)
 
-TaskKey[Unit]("check", "Checks c depends on a & b using `allModules`") := {
-  val expected = List(
-    ClasspathDependency(LocalProject("b"), None),
-    ClasspathDependency(LocalProject("a"), None)
-  )
-
-  assert(c.dependencies == expected, s"Found: ${c.dependencies}\nExpected: $expected")
+TaskKey[Unit]("check", "Checks skip in publish for every module in build") := {
+  assert(!(a / publish / skip).value)
+  assert(!(b / publish / skip).value)
+  assert((c / publish / skip).value)
+  assert((d / publish / skip).value)
+  assert((LocalRootProject / publish / skip).value)
 }

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/test
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/all-modules/test
@@ -1,2 +1,2 @@
-# this test ensures `allModules` contains the list of modules
+# this test ensures `skip in publish` setting is set correctly
 > check

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/simple/build.sbt
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/simple/build.sbt
@@ -1,12 +1,21 @@
 lazy val a = module
 lazy val b = module
 
-TaskKey[Unit]("check", "Checks all base directories are correct") := {
+TaskKey[Unit]("checkModules", "Checks all base directories are correct") := {
   assertFiles(a.base, file("modules") / "a")
   assertFiles((baseDirectory in a).value, file("modules") / "a")
 
   assertFiles(b.base, file("modules") / "b")
   assertFiles((baseDirectory in b).value, file("modules") / "b")
+}
+
+TaskKey[Unit]("checkRoot", "Checks root project aggregates modules") := {
+  val aggregate = (LocalRootProject / thisProject).value.aggregate
+  val base = (LocalRootProject / thisProject).value.base
+
+  val expected = List(ProjectRef(base, "b"), ProjectRef(base, "a"))
+
+  assert(aggregate == expected, s"Found: $aggregate}\nExpected: $expected")
 }
 
 def assertFiles(file1: File, file2: File): Unit =

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/simple/test
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/simple/test
@@ -1,2 +1,3 @@
 # this test ensures modules are instantiated from "modules" folder
-> check
+> checkModules
+> checkRoot

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/skip-in-publish/build.sbt
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/skip-in-publish/build.sbt
@@ -1,0 +1,13 @@
+lazy val a = module
+lazy val b = module
+
+lazy val c = project.dependsOn(allModules: _*)
+
+TaskKey[Unit]("check", "Checks c depends on a & b using `allModules`") := {
+  val expected = List(
+    ClasspathDependency(LocalProject("b"), None),
+    ClasspathDependency(LocalProject("a"), None)
+  )
+
+  assert(c.dependencies == expected, s"Found: ${c.dependencies}\nExpected: $expected")
+}

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/skip-in-publish/project/plugins.sbt
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/skip-in-publish/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-modules"   % sys.props("plugin.version"))

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/skip-in-publish/test
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/skip-in-publish/test
@@ -1,0 +1,2 @@
+# this test ensures `allModules` contains the list of modules
+> check


### PR DESCRIPTION
Forget about setting `skip in publish := true` again. Adding this plugin to your build will disable publishing for all the projects in the build (including the auto-generated root plugin), except for those created with `module`.

However, if you also want to exclude any of those created with `module` you can always add `.settings(skip in publish := true)`.

Example:

```sbt
// Will not be published
lazy val documentation = project.dependsOn(allmodules: _*)

// Will be published
lazy val `my-library-plugin` = module.dependsOn(`my-library-core`)

// Will be published
lazy val `my-library-core` = module

// Will not be published
lazy val `my-library-util` = module.settings(skip in publish := true)
```