### PR TITLE
Expose dependency configuration in `ModuleMetadata`

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -107,8 +107,8 @@ lazy val `my-library-util` = module.settings(publish / skip := true)
 The `moduleMetadata` task key provides a `Map[String, ModuleMetadata]` containing metadata for all modules in the build. Each `ModuleMetadata` includes:
 
 - `version`: the module's version (from the SBT `version` setting)
-- `internalDeps`: names of modules this module directly depends on
-- `dependents`: names of modules that directly depend on this module
+- `dependencies`: the modules this module directly depends on, each a `ModuleDependency` carrying the `dependsOn` edge's configuration (e.g. `"compile"`, `"test"`)
+- `dependents`: the modules that directly depend on this module, each a `ModuleDependency` with the incoming edge's configuration
 - `transitiveDependencies`: names of all modules this module transitively depends on
 - `transitiveDependents`: names of all modules that transitively depend on this module
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion                  := _root_.scalafix.sbt.BuildInfo.scala212
 ThisBuild / organization                  := "com.alejandrohdezma"
 ThisBuild / pluginCrossBuild / sbtVersion := "1.2.8"
-ThisBuild / versionPolicyIntention        := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention        := Compatibility.None
 
 addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc; scripted")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")

--- a/modules/sbt-modules/src/main/scala/com/alejandrohdezma/sbt/modules/ModuleMetadata.scala
+++ b/modules/sbt-modules/src/main/scala/com/alejandrohdezma/sbt/modules/ModuleMetadata.scala
@@ -22,24 +22,35 @@ import sbt._
 
 import com.alejandrohdezma.sbt.modules.ModulesPlugin.autoImport.packageIsModule
 
+/** A direct dependency edge between two modules.
+  *
+  * @param name
+  *   the name of the module on the other end of the edge
+  * @param configuration
+  *   the Ivy configuration mapping of the `dependsOn` edge, as recorded by SBT and normalized so that a default
+  *   `dependsOn` (which SBT leaves unset) is reported as `"compile"`. Examples: `"compile"`, `"test"`, `"test->test"`,
+  *   `"compile->compile;test->test"`. Consumers decide what each scope means.
+  */
+final case class ModuleDependency(name: String, configuration: String)
+
 /** Represents an SBT module created with the [[ModulesPlugin.autoImport.module module]] macro.
   *
   * @param version
   *   the current version from the SBT `version` setting
   * @param dependencies
-  *   names of other modules this module depends on (via SBT `dependsOn`)
+  *   the modules this module directly depends on (via SBT `dependsOn`), each with the edge's configuration
   * @param transitiveDependencies
-  *   names of all modules this module transitively depends on
+  *   names of all modules this module transitively depends on (over all scopes)
   * @param dependents
-  *   names of modules that directly depend on this module (reverse of `internalDeps`)
+  *   the modules that directly depend on this module, each carrying the configuration of the incoming edge
   * @param transitiveDependents
-  *   names of all modules that transitively depend on this module
+  *   names of all modules that transitively depend on this module (over all scopes)
   */
 final case class ModuleMetadata(
     version: String,
-    dependencies: Set[String],
+    dependencies: Set[ModuleDependency],
     transitiveDependencies: Set[String],
-    dependents: Set[String],
+    dependents: Set[ModuleDependency],
     transitiveDependents: Set[String]
 )
 
@@ -69,17 +80,18 @@ object ModuleMetadata {
       val version      = extracted.get(ref / Keys.version)
       val dependencies = buildDeps.classpath.getOrElse(ref, Nil)
       val internal     = dependencies.collect {
-        case dep if namesByProject.contains(dep.project.project) => namesByProject(dep.project.project)
+        case dep if namesByProject.contains(dep.project.project) =>
+          ModuleDependency(namesByProject(dep.project.project), dep.configuration.getOrElse("compile"))
       }.toSet
 
       name -> ModuleMetadata(version = version, dependencies = internal, transitiveDependencies = Set.empty,
         dependents = Set.empty, transitiveDependents = Set.empty)
     }.toMap
 
-    // Second pass: populate direct dependents from the reverse of dependencies
-    val dependentsByModule = initial.foldLeft(Map.empty[String, Set[String]]) { case (acc, (name, info)) =>
+    // Second pass: populate direct dependents from the reverse of dependencies (carrying each edge's configuration)
+    val dependentsByModule = initial.foldLeft(Map.empty[String, Set[ModuleDependency]]) { case (acc, (name, info)) =>
       info.dependencies.foldLeft(acc) { (acc, dep) =>
-        acc.updated(dep, acc.getOrElse(dep, Set.empty) + name)
+        acc.updated(dep.name, acc.getOrElse(dep.name, Set.empty) + ModuleDependency(name, dep.configuration))
       }
     }
 
@@ -106,8 +118,8 @@ object ModuleMetadata {
 
     withDependents.map { case (name, info) =>
       name -> info.copy(
-        transitiveDependencies = closure(info.dependencies, _.dependencies),
-        transitiveDependents = closure(info.dependents, _.dependents)
+        transitiveDependencies = closure(info.dependencies.map(_.name), _.dependencies.map(_.name)),
+        transitiveDependents = closure(info.dependents.map(_.name), _.dependents.map(_.name))
       )
     }
   }

--- a/modules/sbt-modules/src/sbt-test/sbt-modules/module-metadata/build.sbt
+++ b/modules/sbt-modules/src/sbt-test/sbt-modules/module-metadata/build.sbt
@@ -1,10 +1,12 @@
-import com.alejandrohdezma.sbt.modules.ModuleMetadata
+import com.alejandrohdezma.sbt.modules.{ModuleDependency, ModuleMetadata}
 
 lazy val core = module
 
 lazy val api = module.dependsOn(core)
 
 lazy val server = module.dependsOn(api)
+
+lazy val consumer = module.dependsOn(core % Test)
 
 TaskKey[Unit]("checkMetadata", "Checks ModuleMetadata.from returns correct data") := {
   val metadata = ModuleMetadata.from(state.value)
@@ -14,20 +16,27 @@ TaskKey[Unit]("checkMetadata", "Checks ModuleMetadata.from returns correct data"
       version = version.value,
       dependencies = Set.empty,
       transitiveDependencies = Set.empty,
-      dependents = Set("api"),
-      transitiveDependents = Set("api", "server")
+      dependents = Set(ModuleDependency("api", "compile"), ModuleDependency("consumer", "test")),
+      transitiveDependents = Set("api", "server", "consumer")
     ),
     "api" -> ModuleMetadata(
       version = version.value,
-      dependencies = Set("core"),
+      dependencies = Set(ModuleDependency("core", "compile")),
       transitiveDependencies = Set("core"),
-      dependents = Set("server"),
+      dependents = Set(ModuleDependency("server", "compile")),
       transitiveDependents = Set("server")
     ),
     "server" -> ModuleMetadata(
       version = version.value,
-      dependencies = Set("api"),
+      dependencies = Set(ModuleDependency("api", "compile")),
       transitiveDependencies = Set("core", "api"),
+      dependents = Set.empty,
+      transitiveDependents = Set.empty
+    ),
+    "consumer" -> ModuleMetadata(
+      version = version.value,
+      dependencies = Set(ModuleDependency("core", "test")),
+      transitiveDependencies = Set("core"),
       dependents = Set.empty,
       transitiveDependents = Set.empty
     )


### PR DESCRIPTION
## :computer: How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## :rocket: What's included in this PR?

`ModuleMetadata.dependencies` and `dependents` now carry the configuration of each `dependsOn` edge through a new `ModuleDependency(name, configuration)` type, instead of bare module names. A plain `dependsOn` is reported as `"compile"`.

This keeps `sbt-modules` scope-agnostic while letting consumers decide what each scope means. The motivating case is `sbt-changesets`: it can exclude modules that depend on a changed module only in test scope (e.g. `dependsOn(other % Test)`) from the set of affected modules, so changing a test-only helper no longer triggers a version bump of its test-only consumers.

Because the `ModuleMetadata` shape changes, this is a breaking release: `versionPolicyIntention` is set to `Compatibility.None` (to be reset after the release).
